### PR TITLE
Enable cache with caffeine

### DIFF
--- a/src/main/java/com/businessprosuite/api/BusinessProSuiteApiApplication.java
+++ b/src/main/java/com/businessprosuite/api/BusinessProSuiteApiApplication.java
@@ -2,8 +2,10 @@ package com.businessprosuite.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class BusinessProSuiteApiApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/businessprosuite/api/impl/company/CompanyServiceImpl.java
+++ b/src/main/java/com/businessprosuite/api/impl/company/CompanyServiceImpl.java
@@ -9,6 +9,7 @@ import com.businessprosuite.api.repository.company.CompanyRepository;
 import com.businessprosuite.api.repository.config.ConfigCompanyRepository;
 import com.businessprosuite.api.repository.config.ConfigCountryRepository;
 import com.businessprosuite.api.service.company.CompanyService;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +33,7 @@ public class CompanyServiceImpl implements CompanyService {
     }
 
     @Override
+    @Cacheable("companies")
     public List<CompanyDTO> findAll() {
         return repo.findAll().stream()
                 .map(this::toDto)

--- a/src/main/java/com/businessprosuite/api/impl/document/DocumentServiceImpl.java
+++ b/src/main/java/com/businessprosuite/api/impl/document/DocumentServiceImpl.java
@@ -8,6 +8,7 @@ import com.businessprosuite.api.repository.company.CompanyRepository;
 import com.businessprosuite.api.service.document.DocumentService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +25,7 @@ public class DocumentServiceImpl implements DocumentService {
     private final CompanyRepository companyRepo;
 
     @Override
+    @Cacheable("documents")
     public List<DocumentDTO> findAll() {
         return docRepo.findAll().stream()
                 .map(this::toDto)

--- a/src/main/java/com/businessprosuite/api/impl/document/DocumentVersionServiceImpl.java
+++ b/src/main/java/com/businessprosuite/api/impl/document/DocumentVersionServiceImpl.java
@@ -8,6 +8,7 @@ import com.businessprosuite.api.repository.document.DocumentRepository;
 import com.businessprosuite.api.service.document.DocumentVersionService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +25,7 @@ public class DocumentVersionServiceImpl implements DocumentVersionService {
     private final DocumentRepository docRepo;
 
     @Override
+    @Cacheable("documentVersions")
     public List<DocumentVersionDTO> findAll() {
         return versionRepo.findAll().stream()
                 .map(this::toDto)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,9 @@
 spring.profiles.active=dev
 spring.application.name=BusinessProSuiteAPI
-# Puerto de la aplicación
+# Puerto de la aplicaciÃ³n
 server.port=8080
 
-# Conexión a MySQL
+# ConexiÃ³n a MySQL
 spring.datasource.url=jdbc:mysql://localhost:3306/BusinessProSuite?useSSL=false&serverTimezone=UTC
 spring.datasource.username=root
 spring.datasource.password=root
@@ -23,3 +23,6 @@ spring.datasource.hikari.idle-timeout=300000
 jwt.secret=TuClaveSecretaMuySegura12345678901234567890
 jwt.expiration=3600000
 
+# Cache configuration
+spring.cache.type=caffeine
+spring.cache.caffeine.spec=maximumSize=500,expireAfterAccess=10m


### PR DESCRIPTION
## Summary
- enable caching at the application level
- cache frequently-used service lookups
- configure caffeine in `application.properties`

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation)*

------
https://chatgpt.com/codex/tasks/task_e_683fa3bf4e44832ca0cc5e69efad05d6