### PR TITLE
Add sample tests and basic README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# BusinessProSuite API
+
+Este proyecto es una API REST construida con Spring Boot. Provee servicios para distintos dominios del sistema (inventario, finanzas, seguridad, usuarios, etc.).
+
+## Requisitos
+
+- Java 17
+- Gradle 8+
+- MySQL 8
+
+## Puesta en marcha
+
+1. Clonar el repositorio.
+2. Configurar las variables de entorno indicadas abajo o editar `src/main/resources/application.properties`.
+3. Ejecutar `./gradlew bootRun` para iniciar la API.
+
+## Variables de entorno principales
+
+- `SPRING_DATASOURCE_URL` – URL de conexión a la base de datos.
+- `SPRING_DATASOURCE_USERNAME` – usuario de la BD.
+- `SPRING_DATASOURCE_PASSWORD` – contraseña de la BD.
+- `JWT_SECRET` – clave secreta para firmar tokens.
+- `JWT_EXPIRATION` – tiempo de expiración en milisegundos.
+
+## Estructura de módulos
+
+El código está organizado por dominios dentro de `com.businessprosuite.api`:
+
+- `controller` – Controladores REST.
+- `service` / `impl` – Interfaces de servicio y sus implementaciones.
+- `repository` – Repositorios JPA.
+- `dto` – Objetos de transferencia.
+- `model` – Entidades JPA.
+
+Cada subpaquete (finance, inventory, user, security, etc.) representa un dominio del negocio.
+
+## Pruebas
+
+Las pruebas unitarias utilizan JUnit 5 y Mockito. Para ejecutarlas:
+
+```bash
+./gradlew test
+```
+
+Algunos tests pueden requerir dependencias adicionales (por ejemplo Testcontainers) que no están incluidas por defecto.

--- a/src/test/java/com/businessprosuite/api/controller/InvoiceControllerIT.java
+++ b/src/test/java/com/businessprosuite/api/controller/InvoiceControllerIT.java
@@ -1,0 +1,35 @@
+package com.businessprosuite.api.controller;
+
+import com.businessprosuite.api.controller.finance.InvoiceController;
+import com.businessprosuite.api.dto.finance.InvoiceDTO;
+import com.businessprosuite.api.service.finance.InvoiceService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(InvoiceController.class)
+class InvoiceControllerIT {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private InvoiceService service;
+
+    @Test
+    void getAll_returnsOk() throws Exception {
+        when(service.findAll()).thenReturn(Collections.emptyList());
+        mockMvc.perform(get("/api/invoices"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+}

--- a/src/test/java/com/businessprosuite/api/controller/UserControllerIT.java
+++ b/src/test/java/com/businessprosuite/api/controller/UserControllerIT.java
@@ -1,0 +1,39 @@
+package com.businessprosuite.api.controller;
+
+import com.businessprosuite.api.controller.user.UserController;
+import com.businessprosuite.api.dto.user.UserDTO;
+import com.businessprosuite.api.service.user.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(UserController.class)
+class UserControllerIT {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserService service;
+
+    @Test
+    void create_returnsCreated() throws Exception {
+        UserDTO dto = UserDTO.builder().id(1).firstName("A").lastName("B").build();
+        when(service.create(any(UserDTO.class))).thenReturn(dto);
+        mockMvc.perform(post("/api/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isCreated());
+    }
+}

--- a/src/test/java/com/businessprosuite/api/service/InventoryCategoryServiceTest.java
+++ b/src/test/java/com/businessprosuite/api/service/InventoryCategoryServiceTest.java
@@ -1,0 +1,50 @@
+package com.businessprosuite.api.service;
+
+import com.businessprosuite.api.dto.inventory.InventoryCategoryDTO;
+import com.businessprosuite.api.impl.inventory.InventoryCategoryServiceImpl;
+import com.businessprosuite.api.model.inventory.InventoryCategory;
+import com.businessprosuite.api.repository.inventory.InventoryCategoryRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class InventoryCategoryServiceTest {
+    @Mock
+    private InventoryCategoryRepository repo;
+
+    @InjectMocks
+    private InventoryCategoryServiceImpl service;
+
+    @Test
+    void findById_success() {
+        InventoryCategory entity = new InventoryCategory();
+        entity.setId(1);
+        entity.setInvCatName("Cat1");
+        entity.setInvCatDescription("desc");
+        entity.setInvCatCreatedAt(LocalDateTime.now());
+        entity.setInvCatUpdatedAt(LocalDateTime.now());
+        when(repo.findById(1)).thenReturn(Optional.of(entity));
+
+        InventoryCategoryDTO dto = service.findById(1);
+
+        assertEquals(1, dto.getId());
+        verify(repo).findById(1);
+    }
+
+    @Test
+    void delete_notFound() {
+        when(repo.existsById(1)).thenReturn(false);
+        assertThrows(EntityNotFoundException.class, () -> service.delete(1));
+    }
+}

--- a/src/test/java/com/businessprosuite/api/service/SecurityUserServiceTest.java
+++ b/src/test/java/com/businessprosuite/api/service/SecurityUserServiceTest.java
@@ -1,0 +1,61 @@
+package com.businessprosuite.api.service;
+
+import com.businessprosuite.api.dto.security.SecurityUserDTO;
+import com.businessprosuite.api.impl.security.SecurityUserServiceImpl;
+import com.businessprosuite.api.model.company.Company;
+import com.businessprosuite.api.model.security.SecurityRole;
+import com.businessprosuite.api.model.security.SecurityUser;
+import com.businessprosuite.api.repository.company.CompanyRepository;
+import com.businessprosuite.api.repository.security.SecurityRoleRepository;
+import com.businessprosuite.api.repository.security.SecurityUserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SecurityUserServiceTest {
+    @Mock
+    private SecurityUserRepository userRepo;
+    @Mock
+    private SecurityRoleRepository roleRepo;
+    @Mock
+    private CompanyRepository companyRepo;
+
+    @InjectMocks
+    private SecurityUserServiceImpl service;
+
+    @Test
+    void findById_success() {
+        SecurityRole role = new SecurityRole();
+        role.setId(2);
+        Company cmp = new Company();
+        cmp.setId(3);
+        SecurityUser user = new SecurityUser();
+        user.setId(1);
+        user.setSecusName("user1");
+        user.setSecusRole(role);
+        user.setSecusCmp(cmp);
+        when(userRepo.findById(1)).thenReturn(Optional.of(user));
+
+        SecurityUserDTO dto = service.findById(1);
+
+        assertEquals(1, dto.getId());
+        verify(userRepo).findById(1);
+    }
+
+    @Test
+    void delete_notFound() {
+        when(userRepo.existsById(9)).thenReturn(false);
+        assertThrows(EntityNotFoundException.class, () -> service.delete(9));
+    }
+}

--- a/src/test/java/com/businessprosuite/api/service/TranslationServiceTest.java
+++ b/src/test/java/com/businessprosuite/api/service/TranslationServiceTest.java
@@ -1,0 +1,58 @@
+package com.businessprosuite.api.service;
+
+import com.businessprosuite.api.dto.core.TranslationDTO;
+import com.businessprosuite.api.impl.core.TranslationServiceImpl;
+import com.businessprosuite.api.model.core.Translation;
+import com.businessprosuite.api.repository.core.TranslationRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TranslationServiceTest {
+    @Mock
+    private TranslationRepository repo;
+
+    @InjectMocks
+    private TranslationServiceImpl service;
+
+    @Test
+    void create_success() {
+        TranslationDTO dto = TranslationDTO.builder()
+                .lang("es")
+                .key("hello")
+                .value("hola")
+                .build();
+
+        Translation saved = new Translation();
+        saved.setId(1);
+        saved.setIntLang("es");
+        saved.setIntKey("hello");
+        saved.setIntValue("hola");
+        saved.setIntCreatedAt(LocalDateTime.now());
+        saved.setIntUpdatedAt(LocalDateTime.now());
+
+        when(repo.save(any(Translation.class))).thenReturn(saved);
+
+        TranslationDTO result = service.create(dto);
+
+        assertEquals(1, result.getId());
+        verify(repo).save(any(Translation.class));
+    }
+
+    @Test
+    void findById_notFound() {
+        when(repo.findById(1)).thenReturn(Optional.empty());
+        assertThrows(EntityNotFoundException.class, () -> service.findById(1));
+    }
+}

--- a/src/test/java/com/businessprosuite/api/service/UserServiceTest.java
+++ b/src/test/java/com/businessprosuite/api/service/UserServiceTest.java
@@ -1,0 +1,39 @@
+package com.businessprosuite.api.service;
+
+import com.businessprosuite.api.dto.user.UserDTO;
+import com.businessprosuite.api.impl.user.UserServiceImpl;
+import com.businessprosuite.api.model.user.User;
+import com.businessprosuite.api.repository.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+    @Mock
+    private UserRepository repo;
+
+    @InjectMocks
+    private UserServiceImpl service;
+
+    @Test
+    void findById_success() {
+        User user = new User();
+        user.setId(5);
+        user.setUsrFirstName("Agustin");
+        user.setUsrLastName("Test");
+        when(repo.findById(5)).thenReturn(Optional.of(user));
+
+        UserDTO result = service.findById(5);
+
+        assertEquals(5, result.getId());
+        verify(repo).findById(5);
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple README with build instructions and env vars
- implement unit tests for several services
- add integration tests for `InvoiceController` and `UserController`

## Testing
- `./gradlew test` *(fails: cannot find symbol PK, missing JwtUtil)*

------
https://chatgpt.com/codex/tasks/task_e_683fa3c1275c832c84746766baeb8100