### PR TITLE
Add login endpoint with JWT generation

### DIFF
--- a/src/main/java/com/businessprosuite/api/config/SecurityConfig.java
+++ b/src/main/java/com/businessprosuite/api/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
                 .authenticationProvider(authProvider())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/auth/**",
+                                "/auth/login",
                                 "/companies/**",
                                 "/roles/**",
                                 "/swagger-ui.html",

--- a/src/main/java/com/businessprosuite/api/controller/auth/AuthController.java
+++ b/src/main/java/com/businessprosuite/api/controller/auth/AuthController.java
@@ -1,0 +1,34 @@
+package com.businessprosuite.api.controller.auth;
+
+import com.businessprosuite.api.dto.auth.AuthRequestDTO;
+import com.businessprosuite.api.dto.auth.AuthResponseDTO;
+import com.businessprosuite.api.security.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthenticationManager authManager;
+    private final JwtUtil jwtUtil;
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponseDTO> login(@RequestBody AuthRequestDTO request) {
+        Authentication authentication = authManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword())
+        );
+        UserDetails user = (UserDetails) authentication.getPrincipal();
+        String token = jwtUtil.generateToken(user);
+        return ResponseEntity.ok(AuthResponseDTO.builder().token(token).build());
+    }
+}

--- a/src/main/java/com/businessprosuite/api/dto/auth/AuthRequestDTO.java
+++ b/src/main/java/com/businessprosuite/api/dto/auth/AuthRequestDTO.java
@@ -1,0 +1,13 @@
+package com.businessprosuite.api.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthRequestDTO {
+    private String username;
+    private String password;
+}

--- a/src/main/java/com/businessprosuite/api/dto/auth/AuthResponseDTO.java
+++ b/src/main/java/com/businessprosuite/api/dto/auth/AuthResponseDTO.java
@@ -1,0 +1,14 @@
+package com.businessprosuite.api.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AuthResponseDTO {
+    private String token;
+}


### PR DESCRIPTION
## Summary
- implement `AuthController` to authenticate credentials
- create `AuthRequestDTO` and `AuthResponseDTO`
- expose `/auth/login` in `SecurityConfig`

## Testing
- `./gradlew test` *(fails: Could not determine dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683fb00a01a4832cada06d4444f6ad6d