### PR TITLE
Enable caching on read-heavy services

### DIFF
--- a/src/main/java/com/businessprosuite/api/impl/config/ConfigCompanyServiceImpl.java
+++ b/src/main/java/com/businessprosuite/api/impl/config/ConfigCompanyServiceImpl.java
@@ -4,6 +4,7 @@ import com.businessprosuite.api.dto.config.ConfigCompanyDTO;
 import com.businessprosuite.api.model.config.ConfigCompany;
 import com.businessprosuite.api.repository.config.ConfigCompanyRepository;
 import com.businessprosuite.api.service.config.ConfigCompanyService;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +22,7 @@ public class ConfigCompanyServiceImpl implements ConfigCompanyService {
     }
 
     @Override
+    @Cacheable("configCompanies")
     public List<ConfigCompanyDTO> findAll() {
         return repo.findAll().stream()
                 .map(this::toDto)

--- a/src/main/java/com/businessprosuite/api/impl/config/ConfigCountryServiceImplementation.java
+++ b/src/main/java/com/businessprosuite/api/impl/config/ConfigCountryServiceImplementation.java
@@ -4,6 +4,7 @@ import com.businessprosuite.api.dto.config.ConfigCountryDTO;
 import com.businessprosuite.api.model.config.ConfigCountry;
 import com.businessprosuite.api.repository.config.ConfigCountryRepository;
 import com.businessprosuite.api.service.config.ConfigCountryService;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +22,7 @@ public class ConfigCountryServiceImplementation implements ConfigCountryService 
     }
 
     @Override
+    @Cacheable("configCountries")
     public List<ConfigCountryDTO> findAll() {
         return repo.findAll().stream()
                 .map(this::toDto)

--- a/src/main/java/com/businessprosuite/api/impl/customer/CustomerServiceImpl.java
+++ b/src/main/java/com/businessprosuite/api/impl/customer/CustomerServiceImpl.java
@@ -12,6 +12,7 @@ import com.businessprosuite.api.repository.config.ConfigCountryRepository;
 import com.businessprosuite.api.service.customer.CustomerService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +31,7 @@ public class CustomerServiceImpl implements CustomerService {
     private final ConfigCountryRepository countryRepo;
 
     @Override
+    @Cacheable("customers")
     public List<CustomerDTO> findAll() {
         return customerRepo.findAll().stream()
                 .map(this::toDto)

--- a/src/main/java/com/businessprosuite/api/impl/finance/CurrencyServiceImpl.java
+++ b/src/main/java/com/businessprosuite/api/impl/finance/CurrencyServiceImpl.java
@@ -6,6 +6,7 @@ import com.businessprosuite.api.repository.finance.CurrencyRepository;
 import com.businessprosuite.api.service.finance.CurrencyService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +22,7 @@ public class CurrencyServiceImpl implements CurrencyService {
     private final CurrencyRepository repo;
 
     @Override
+    @Cacheable("currencies")
     public List<CurrencyDTO> findAll() {
         return repo.findAll()
                 .stream()

--- a/src/main/java/com/businessprosuite/api/impl/finance/FinanceCOAServiceImpl.java
+++ b/src/main/java/com/businessprosuite/api/impl/finance/FinanceCOAServiceImpl.java
@@ -8,6 +8,7 @@ import com.businessprosuite.api.repository.finance.FinanceCOARepository;
 import com.businessprosuite.api.service.finance.FinanceCOAService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +25,7 @@ public class FinanceCOAServiceImpl implements FinanceCOAService {
     private final CompanyRepository    companyRepo;
 
     @Override
+    @Cacheable("financeCoas")
     public List<FinanceCOADTO> findAll() {
         return coaRepo.findAll().stream()
                 .map(this::toDto)


### PR DESCRIPTION
## Summary
- cache results of `CustomerServiceImpl.findAll`
- cache results of `CurrencyServiceImpl.findAll`
- cache results of `ConfigCountryServiceImplementation.findAll`
- cache results of `ConfigCompanyServiceImpl.findAll`
- cache results of `FinanceCOAServiceImpl.findAll`

## Testing
- `./gradlew test` *(fails: Could not determine the dependencies of task ':test')*

------
https://chatgpt.com/codex/tasks/task_e_683fb0137ee8832c8aa3ebb73f2ca1a4