### PR TITLE
Add InfoController tests

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -17,6 +17,12 @@ Este documento resume los cambios recientes implementados y cómo ejecutar la AP
 
 - **Notificaciones**
   - Las notificaciones en cola pueden enviarse por correo usando `/api/notification-queue/dispatch`.
+- **Versión**
+  - El endpoint `/api/version` devuelve la versión configurada.
+  - `/api/info` ahora muestra versión, descripción y el entorno.
+  - El entorno se define con la variable de entorno `APP_ENVIRONMENT`.
+  - La versión y descripción pueden definirse con `APP_VERSION` y
+    `APP_DESCRIPTION`.
 
 ## Ejecución en macOS (M4 Max)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Cambios de la API
+## v0.0.3
+- `app.version` y `app.description` pueden configurarse con las variables de entorno `APP_VERSION` y `APP_DESCRIPTION`.
+## v0.0.2
+- Nuevo endpoint `/api/version` para consultar la versión de la API.
+- Valor de la versión configurable en `application.properties` (app.version).
+- Se añadió propiedad `app.description` para describir la API.
+- Nuevo endpoint `/api/info` que devuelve versión y descripción.
+- Nueva propiedad `app.environment` para indicar el entorno y ahora `/api/info` la retorna.
+- La propiedad puede fijarse mediante la variable de entorno `APP_ENVIRONMENT`.
+- Se añadieron pruebas de `InfoController` para `/api/version` y `/api/info`.
 
 ## v0.0.1
 - Implementación de cuentas por pagar y cobrar en Finanzas.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BusinessProSuite API (v0.0.1)
+# BusinessProSuite API (v0.0.3)
 
 Este proyecto es una API REST construida con Spring Boot. Provee servicios para distintos dominios del sistema (inventario, finanzas, seguridad, usuarios, etc.).
 
@@ -21,6 +21,10 @@ Este proyecto es una API REST construida con Spring Boot. Provee servicios para 
 - `SPRING_DATASOURCE_PASSWORD` – contraseña de la BD.
 - `JWT_SECRET` – clave secreta para firmar tokens.
 - `JWT_EXPIRATION` – tiempo de expiración en milisegundos.
+- `APP_ENVIRONMENT` – entorno de ejecución (dev, prod, etc.),
+  usado para la propiedad `app.environment`.
+- `APP_VERSION` – versión desplegada (opcional, por defecto `0.0.3`).
+- `APP_DESCRIPTION` – descripción de la API (opcional).
 
 ## Estructura de módulos
 
@@ -38,6 +42,8 @@ Desde 2025 se cuenta además con el endpoint `/api/hr/payrolls` para gestionar l
 Además se habilitó inicio de sesión mediante OAuth2 para proveedores externos (por ejemplo Google). Configurar las credenciales en `application.properties` usando el prefijo `spring.security.oauth2.client`.
 También se incorpora autenticación multifactor (MFA) con TOTP. Usa los endpoints bajo `/api/mfa` para activar y verificar códigos.
 El sistema de notificaciones ahora permite enviar correos mediante `/api/notification-queue/dispatch`.
+Se añadió el endpoint `/api/version` para consultar la versión desplegada.
+También se incorporó `/api/info` que muestra la versión, descripción y entorno de ejecución.
 
 ## Pruebas
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.businessprosuite.api'
-version = '0.0.1'
+version = '0.0.3'
 
 java {
     toolchain {

--- a/futures.md
+++ b/futures.md
@@ -108,3 +108,7 @@ Estas tareas implican generar nuevas entidades, servicios y controladores en los
 - **Security**: se implementó autenticación multifactor TOTP con nuevos endpoints y servicio `TotpService`.
 - **Notification**: la cola de notificaciones ahora puede despachar correos mediante `/api/notification-queue/dispatch`.
 - **Versión**: primera versión estable etiquetada como `v0.0.1`.
+- **Versión**: liberada `v0.0.2` con el endpoint `/api/version` para consultar la versión de la API.
+- **Versión**: `/api/info` muestra la versión y descripción configuradas.
+- **Versión**: `/api/info` ahora también expone el entorno mediante `app.environment`.
+- **Versión**: liberada `v0.0.3` con soporte de variables `APP_VERSION` y `APP_DESCRIPTION`.

--- a/src/main/java/com/businessprosuite/api/controller/info/InfoController.java
+++ b/src/main/java/com/businessprosuite/api/controller/info/InfoController.java
@@ -1,0 +1,40 @@
+package com.businessprosuite.api.controller.info;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api")
+public class InfoController {
+
+    @Value("${app.version}")
+    private String appVersion;
+
+    @Value("${app.description}")
+    private String appDescription;
+
+    @Value("${app.environment:local}")
+    private String appEnvironment;
+
+    @GetMapping("/version")
+    public ResponseEntity<Map<String, String>> getVersion() {
+        return ResponseEntity.ok(Map.of("version", appVersion));
+    }
+
+    /**
+     * Devuelve información básica de la API.
+     */
+    @GetMapping("/info")
+    public ResponseEntity<Map<String, String>> getInfo() {
+        return ResponseEntity.ok(Map.of(
+                "version", appVersion,
+                "description", appDescription,
+                "environment", appEnvironment
+        ));
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,3 +26,9 @@ jwt.expiration=3600000
 # Cache configuration
 spring.cache.type=caffeine
 spring.cache.caffeine.spec=maximumSize=500,expireAfterAccess=10m
+
+# Versión de la aplicación
+app.version=${APP_VERSION:0.0.3}
+app.description=${APP_DESCRIPTION:BusinessProSuite API REST}
+app.environment=${APP_ENVIRONMENT:dev}
+

--- a/src/test/java/com/businessprosuite/api/controller/InfoControllerIT.java
+++ b/src/test/java/com/businessprosuite/api/controller/InfoControllerIT.java
@@ -1,0 +1,39 @@
+package com.businessprosuite.api.controller;
+
+import com.businessprosuite.api.controller.info.InfoController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(InfoController.class)
+@TestPropertySource(properties = {
+        "app.version=1.2.3",
+        "app.description=Test API",
+        "app.environment=test"
+})
+class InfoControllerIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void getVersion_returnsOk() throws Exception {
+        mockMvc.perform(get("/api/version"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.version").value("1.2.3"));
+    }
+
+    @Test
+    void getInfo_returnsOk() throws Exception {
+        mockMvc.perform(get("/api/info"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.version").value("1.2.3"))
+                .andExpect(jsonPath("$.description").value("Test API"))
+                .andExpect(jsonPath("$.environment").value("test"));
+    }
+}


### PR DESCRIPTION
## Summary
- create InfoControllerIT covering `/api/version` and `/api/info`
- document new tests in CHANGELOG
- make `app.version` and `app.description` configurable via `APP_VERSION` and `APP_DESCRIPTION`
- bump version to v0.0.3 in docs and configuration

## Testing
- `./gradlew test --no-daemon` *(fails: Cannot find a Java installation matching Java 17)*

------
https://chatgpt.com/codex/tasks/task_e_68685299856c832cbf7cd9522b1af7a8