### PR TITLE
Fix JPA entity scanning

### DIFF
--- a/src/main/java/com/businessprosuite/api/BusinessProSuiteApiApplication.java
+++ b/src/main/java/com/businessprosuite/api/BusinessProSuiteApiApplication.java
@@ -2,10 +2,14 @@ package com.businessprosuite.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
 @EnableCaching
+@EntityScan("com.businessprosuite.api.model")
+@EnableJpaRepositories("com.businessprosuite.api.repository")
 public class BusinessProSuiteApiApplication {
 
     public static void main(String[] args) {


### PR DESCRIPTION
## Summary
- configure package scanning for JPA entities and repositories in BusinessProSuiteApiApplication

## Testing
- `./gradlew test` *(fails: NoSuchBeanDefinitionException)*

------
https://chatgpt.com/codex/tasks/task_e_68688e26b154832cadea4a1e7e395918