### PR TITLE
Fix duplicate column mapping in AuditTrail

### DIFF
--- a/src/main/java/com/businessprosuite/api/model/audit/AuditTrail.java
+++ b/src/main/java/com/businessprosuite/api/model/audit/AuditTrail.java
@@ -21,11 +21,13 @@ public class AuditTrail {
 
     @Size(max = 100)
     @NotNull
-    @Column(name = "auda_table", nullable = false, length = 100)
+    @Column(name = "auda_table", nullable = false, length = 100,
+            insertable = false, updatable = false)
     private String audaTable;
 
     @NotNull
-    @Column(name = "auda_record_id", nullable = false)
+    @Column(name = "auda_record_id", nullable = false,
+            insertable = false, updatable = false)
     private Integer audaRecordId;
 
     @NotNull
@@ -39,7 +41,8 @@ public class AuditTrail {
 
     @NotNull
     @ColumnDefault("CURRENT_TIMESTAMP")
-    @Column(name = "auda_changed_at", nullable = false)
+    @Column(name = "auda_changed_at", nullable = false,
+            insertable = false, updatable = false)
     private LocalDateTime audaChangedAt;
 
     @Size(max = 100)


### PR DESCRIPTION
## Summary
- resolve Hibernate MappingException by marking AuditTrail ID columns as read-only

## Testing
- `./gradlew test --no-daemon` *(fails: No bean named 'entityManagerFactory' available)*

------
https://chatgpt.com/codex/tasks/task_e_686985600b5c832c830c34353317cc70