### PR TITLE
Add Flyway baseline and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - `app.version` y `app.description` pueden configurarse con las variables de entorno `APP_VERSION` y `APP_DESCRIPTION`.
 - Gradle puede descargar automáticamente la JDK requerida para las pruebas.
 - Nueva propiedad `app.name` configurable con `APP_NAME` y devuelta en `/api/info`.
+- Se añadió script inicial de Flyway `V1__baseline.sql` y documentación de migraciones.
 ## v0.0.2
 - Nuevo endpoint `/api/version` para consultar la versión de la API.
 - Valor de la versión configurable en `application.properties` (app.version).

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ Si es la primera vez que ejecutas la API de forma local sigue estos pasos:
 - `APP_DESCRIPTION` – descripción de la API (opcional).
 - `APP_NAME` – nombre de la aplicación (opcional, por defecto `BusinessProSuite`).
 
+## Migraciones de base de datos
+
+Para controlar el orden de creacion del esquema en produccion se usa Flyway.
+Coloca los scripts en `src/main/resources/db/migration` numerados como `V1__`, `V2__`, etc.
+El archivo `V1__baseline.sql` crea las tablas basicas (`usr_roles`, `usr_users` y `usr_user_roles`) en ese orden.
+En desarrollo Hibernate puede seguir actualizando el esquema con `spring.jpa.hibernate.ddl-auto=update`.
+
+
 ## Estructura de módulos
 
 El código está organizado por dominios dentro de `com.businessprosuite.api`:

--- a/src/main/resources/db/migration/V1__baseline.sql
+++ b/src/main/resources/db/migration/V1__baseline.sql
@@ -1,0 +1,29 @@
+-- Baseline de tablas principales para usuarios
+CREATE TABLE IF NOT EXISTS usr_roles (
+    usr_role_id INT AUTO_INCREMENT PRIMARY KEY,
+    usr_role_name VARCHAR(50) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS usr_users (
+    usr_id INT AUTO_INCREMENT PRIMARY KEY,
+    usr_cmp_id INT NOT NULL,
+    usr_first_name VARCHAR(100) NOT NULL,
+    usr_last_name VARCHAR(100) NOT NULL,
+    usr_email VARCHAR(255),
+    usr_phone VARCHAR(50),
+    usr_residence VARCHAR(2),
+    usr_consent TINYINT DEFAULT 0,
+    usr_consent_date DATETIME,
+    usr_address VARCHAR(255),
+    usr_id_number VARCHAR(50),
+    usr_created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    usr_updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS usr_user_roles (
+    usr_user_role_usr_id INT NOT NULL,
+    usr_user_role_role_id INT NOT NULL,
+    PRIMARY KEY (usr_user_role_usr_id, usr_user_role_role_id),
+    CONSTRAINT fk_usr_roles_user FOREIGN KEY (usr_user_role_usr_id) REFERENCES usr_users(usr_id),
+    CONSTRAINT fk_usr_roles_role FOREIGN KEY (usr_user_role_role_id) REFERENCES usr_roles(usr_role_id)
+);


### PR DESCRIPTION
## Summary
- document how to manage migrations using Flyway
- add Flyway baseline script for initial user tables
- note new script in the changelog

## Testing
- `./gradlew test` *(fails: BeanCreationException)*

------
https://chatgpt.com/codex/tasks/task_e_686993cfd904832cacbe7508e7f7db0b