### PR TITLE
Habilitar puertos locales extra en CORS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Cambios de la API
 ## v0.0.3
+- Se habilitaron peticiones CORS desde `localhost` en los puertos `3000-3010`.
 - `app.version` y `app.description` pueden configurarse con las variables de entorno `APP_VERSION` y `APP_DESCRIPTION`.
 - Gradle puede descargar automáticamente la JDK requerida para las pruebas.
 - Nueva propiedad `app.name` configurable con `APP_NAME` y devuelta en `/api/info`.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ Si es la primera vez que ejecutas la API de forma local sigue estos pasos:
 6. Accede a <http://localhost:8080/swagger-ui.html> para comprobar que la API está
    en funcionamiento.
 
+### Conexión desde el front-end local
+
+El CORS de la API permite peticiones desde `localhost` en los puertos `3000` al
+`3010`. Esto facilita integrar aplicaciones web durante el desarrollo.
+
 ## Variables de entorno principales
 
 - `SPRING_DATASOURCE_URL` – URL de conexión a la base de datos.

--- a/src/main/java/com/businessprosuite/api/config/WebConfig.java
+++ b/src/main/java/com/businessprosuite/api/config/WebConfig.java
@@ -11,7 +11,18 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry
                 .addMapping("/**")                                     // aplica a todos los endpoints
-                .allowedOrigins("http://localhost:3000")                          // dominio(s) permitidos
+                .allowedOrigins(
+                        "http://localhost:3000",
+                        "http://localhost:3001",
+                        "http://localhost:3002",
+                        "http://localhost:3003",
+                        "http://localhost:3004",
+                        "http://localhost:3005",
+                        "http://localhost:3006",
+                        "http://localhost:3007",
+                        "http://localhost:3008",
+                        "http://localhost:3009",
+                        "http://localhost:3010")                         // dominios permitidos
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true)


### PR DESCRIPTION
## Summary
- extend CORS configuration to allow `localhost` ports `3000`-`3010`
- document local front-end ports in README
- note the new CORS setting in CHANGELOG

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6869f91b039c832c94ea220a1ae1ed8e